### PR TITLE
Fix Magic CD to Go Directory

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   name: vagrant-go-dev
-  version: 'v1.1.0'
+  version: 'v1.1.1'
   author: Naftuli Kay
   description: Install and configure a Go development environment in a Vagrant machine.
 
@@ -20,4 +20,3 @@ galaxy_info:
 dependencies:
   - role: naftulikay.go-dev
   - role: naftulikay.vagrant-base
-    vagrant_init_dir: "{{ _vagrant_init_dir }}"

--- a/tests/goss.d/files.yml
+++ b/tests/goss.d/files.yml
@@ -2,13 +2,12 @@
 file:
   '/usr/local/go/bin/go': { exists: true }
   # test that the magic exists
-  /home/vagrant/.bashrc:
+  /etc/profile.d/vagrant-magic.sh:
     exists: true
-    mode: "0750"
-    owner: vagrant
-    group: vagrant
+    mode: "0755"
+    owner: root
+    group: root
     filetype: file
     contains:
-      - "#!/usr/bin/env bash"
       - "if [ $(history 2>/dev/null | wc -l) -eq 0 ]; then"
       - "cd \"{{.Env.cd_dir}}\""

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -24,4 +24,4 @@
       goss_file: goss.yml
       goss_addtl_dirs: [goss.d/]
       goss_env_vars:
-        cd_dir: "/home/vagrant/.go/src/github.com/naftulikay/ansible-role-vagrant-go-dev"
+        cd_dir: "$HOME/.go/src/github.com/naftulikay/ansible-role-vagrant-go-dev"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 ---
-go_user: "{{ vagrant_user }}"
-_vagrant_init_dir: "/home/vagrant/.go/src/{{ go_package }}"
+vagrant_init_dir: "$HOME/.go/src/{{ go_package }}"
 vagrant_user: vagrant
+
+go_user: "{{ vagrant_user }}"


### PR DESCRIPTION
This now works as expected. Had to move variables in vagrant-base to the defaults folder as opposed to the vars folder due to precedence.